### PR TITLE
Calendar repo restructuring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,6 @@ dmypy.json
 
 # Pycharm stuff
 .idea/
+
+# courtbot stuff
+.main.sh

--- a/main.py
+++ b/main.py
@@ -16,7 +16,6 @@ def main():
     """
     - Parse court calendars
     - Write json files with court events for each county-division-docket
-    - Write a lookup csv
     - Commit & push new json files and lookup csv
 
     :return:

--- a/main.py
+++ b/main.py
@@ -23,23 +23,17 @@ def main():
     """
     calendar_root_url = courtbot_config.get_config_field("calendar_root_url")
     local_calendar_repo = courtbot_config.get_config_field("local_calendar_repo_path")
-    repo_name = courtbot_config.get_config_field("calendar_repo")
-    github_org = courtbot_config.get_config_field("github_organization")
-    github_branch = courtbot_config.get_config_field("github_branch")
-    link_stub = courtbot_config.get_config_field("github_link_stub")
     today = datetime.date.today().strftime("%Y-%m-%d")
 
     print("Parsing all court calendars found at " + calendar_root_url + "\n")
-    events_csv = parser.parse_all(calendar_root_url, os.path.join(local_calendar_repo, today))
+    events_csv = parser.parse_all(calendar_root_url, local_calendar_repo)
     print("Finished parsing all court calendars\n")
 
     print("Writing json files for parsed court events\n")
-    lookup_table = event_writer.write_events(events_csv, today, local_calendar_repo, repo_name, github_branch,
-                                             github_org, link_stub)
+    event_writer.write_events(events_csv, ".", local_calendar_repo)
     print("Finished writing json files for parsed court events\n")
 
-    event_writer.commit_push(local_calendar_repo, today + "/", "Adding newest court event json files")
-    event_writer.commit_push(local_calendar_repo, os.path.basename(lookup_table),  "Rewriting lookup table")
+    event_writer.commit_push(local_calendar_repo, "." + "/", "Adding newest court event json files")
 
 
 if __name__ == "__main__":

--- a/main.py
+++ b/main.py
@@ -5,8 +5,6 @@ Usage:
 python3 main.py
 
 """
-import os
-import datetime
 import src.parse.calendar_parse as parser
 import src.github_database.write_events as event_writer
 import src.config.config as courtbot_config
@@ -22,7 +20,6 @@ def main():
     """
     calendar_root_url = courtbot_config.get_config_field("calendar_root_url")
     local_calendar_repo = courtbot_config.get_config_field("local_calendar_repo_path")
-    today = datetime.date.today().strftime("%Y-%m-%d")
 
     print("Parsing all court calendars found at " + calendar_root_url + "\n")
     events_csv = parser.parse_all(calendar_root_url, local_calendar_repo)
@@ -37,5 +34,3 @@ def main():
 
 if __name__ == "__main__":
     main()
-
-

--- a/main.sh
+++ b/main.sh
@@ -1,3 +1,0 @@
-source ~/Code/lib/codeforbtv/courtbot-vt/env/bin/activate
-python3 ~/Code/lib/codeforbtv/courtbot-vt/main.py >> /Users/lucasj/.courtbot-vt/test_updates_30m.log 2>&1
-deactivate

--- a/main.sh
+++ b/main.sh
@@ -1,0 +1,3 @@
+source ~/Code/lib/codeforbtv/courtbot-vt/env/bin/activate
+python3 ~/Code/lib/codeforbtv/courtbot-vt/main.py >> /Users/lucasj/.courtbot-vt/test_updates_30m.log 2>&1
+deactivate

--- a/src/config/config.py
+++ b/src/config/config.py
@@ -9,7 +9,7 @@ python3 config.py
 import os
 import yaml
 
-CONFIG_DIR = os.path.expanduser("~/.courtbot-vt")
+CONFIG_DIR = os.path.expanduser(os.path.join("~", ".courtbot-vt"))
 CONFIG_FILE = "config.yaml"
 
 

--- a/src/github_database/write_events.py
+++ b/src/github_database/write_events.py
@@ -26,8 +26,7 @@ def create_docket_link(file_path, github_branch="main", repo_name="court-calenda
     return docket_link
 
 
-def write_events(event_csv, write_dir, local_calendar_repo, repo_name="court-calendars", github_branch="main",
-                 github_org="codeforbtv", link_stub="https://raw.githubusercontent.com"):
+def write_events(event_csv, write_dir, local_calendar_repo):
     """
     Gather events for each unique county-division-docket combination and write json files to the court calendar github
     repo
@@ -35,19 +34,9 @@ def write_events(event_csv, write_dir, local_calendar_repo, repo_name="court-cal
     :param write_dir: string indicating path (relative to local_calendar_repo) to directory where
     county-division-docket json files will be written
     :param local_calendar_repo: string indicating local path to court calendar repo
-    :param repo_name: name of repo where county_division/docket.json files will be stored.
-    :param github_branch: code branch in repo_name where county_division/docket.json files will be pushed.
-    :param github_org: name of github organization where repo_name exists
-    :param link_stub: the generic stub for raw github file content
-    :return: A string indicating local path to lookup csv for matching county-division-docket to a github link
-    containing  the raw json
+    :return:
     """
     calendar_table = pandas.read_csv(event_csv, dtype=str)
-    lookup_table = pandas.DataFrame(dict(
-        docket=calendar_table.docket,
-        county=calendar_table.county,
-        division=calendar_table.division,
-        link=""))
 
     for county in list(set(calendar_table.county)):
         county = county.replace(" ", "_")
@@ -68,16 +57,6 @@ def write_events(event_csv, write_dir, local_calendar_repo, repo_name="court-cal
                 docket_path = os.path.join(court_path, docket + ".json")
                 with open(docket_path, "w") as docket_file:
                     json.dump(docket_events, docket_file)
-                link = create_docket_link(docket_path, github_branch, repo_name, github_org, link_stub)
-                lookup_table.loc[
-                    (calendar_table.docket == docket) &
-                    (calendar_table.county == county) &
-                    (calendar_table.division == division),
-                    "link"] = link
-
-    lookup_table_name = "event_lookup.csv"
-    lookup_table.to_csv(os.path.join(local_calendar_repo, lookup_table_name))
-    return lookup_table_name
 
 
 def commit_push(repo_directory, add_path, message):
@@ -99,7 +78,4 @@ def commit_push(repo_directory, add_path, message):
     except cmd.CalledProcessError as e:
         print("Failed to commit and push with the following error: \n" + str(e))
         return False
-
-
-
 

--- a/src/github_database/write_events.py
+++ b/src/github_database/write_events.py
@@ -78,4 +78,3 @@ def commit_push(repo_directory, add_path, message):
     except cmd.CalledProcessError as e:
         print("Failed to commit and push with the following error: \n" + str(e))
         return False
-

--- a/src/parse/calendar_parse.py
+++ b/src/parse/calendar_parse.py
@@ -308,4 +308,3 @@ def parse_all(calendar_root_url, write_dir):
         dict_writer.writerows(all_court_events)
 
     return write_file
-

--- a/src/parse/calendar_parse.py
+++ b/src/parse/calendar_parse.py
@@ -279,7 +279,6 @@ def parse_all(calendar_root_url, write_dir):
     if not os.path.isdir(write_dir):
         os.mkdir(write_dir)
 
-    date = datetime.date.today().strftime("%Y-%m-%d")
     court_cals = get_court_calendar_urls(calendar_root_url)
     all_court_events = []
     for court_cal in court_cals:

--- a/src/parse/calendar_parse.py
+++ b/src/parse/calendar_parse.py
@@ -301,7 +301,7 @@ def parse_all(calendar_root_url, write_dir):
             print("Done parsing '" + court_name + "' at '" + court_url + "'.\n")
 
     keys = all_court_events[0].keys()
-    write_file = os.path.join(write_dir,  'court_events_' + date + ".csv")
+    write_file = os.path.join(write_dir,  'court_events.csv')
     with open(write_file, 'w') as wf:
         dict_writer = csv.DictWriter(wf, keys)
         dict_writer.writeheader()


### PR DESCRIPTION
Resolves: https://github.com/codeforbtv/courtbot-vt/issues/2

### Description
Instead of writing a new set of parsed data to the [court-calendar repo](https://github.com/codeforbtv/court-calendars) every day, we update what is there. In theory, a historical record of changes and additions can be tracked through the commit history. We don't make removals, only updates and additions. 


### Bug fixes
- the default `config.yaml` path should now be windows OS safe. 